### PR TITLE
Feature/openocd implementation

### DIFF
--- a/debian/librp1jtag-dev.install
+++ b/debian/librp1jtag-dev.install
@@ -1,3 +1,4 @@
 usr/include/rp1_jtag.h
 usr/lib/*/librp1jtag.a
 usr/lib/*/librp1jtag.so
+usr/lib/*/pkgconfig/rp1jtag.pc

--- a/drivers/openocd/README.md
+++ b/drivers/openocd/README.md
@@ -1,0 +1,110 @@
+# OpenOCD Integration
+
+Adapter driver for OpenOCD using RP1 PIO JTAG on Raspberry Pi 5.
+
+## Files
+
+- `rp1_pio_jtag.c` - OpenOCD adapter driver (C, GPL-2.0-or-later)
+- `integrate.py` - Automated integration script
+
+## Quick Start
+
+```bash
+# 1. Install librp1jtag (from the rp1-jtag repo)
+cd /path/to/rp1-jtag
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
+cmake --build build
+sudo cmake --install build
+sudo ldconfig
+
+# 2. Clone and patch OpenOCD
+git clone https://github.com/openocd-org/openocd.git
+python3 integrate.py openocd
+
+# 3. Build OpenOCD
+cd openocd
+./bootstrap
+./configure --enable-rp1-pio-jtag
+make -j$(nproc)
+
+# 4. Use (requires sudo for /dev/pio0 access)
+sudo ./src/openocd -f netv2.cfg
+```
+
+## OpenOCD Configuration
+
+Example config for NeTV2 FPGA board (`netv2.cfg`):
+
+```tcl
+# Adapter
+adapter driver rp1_pio_jtag
+rp1_pio_jtag jtag_nums 4 17 27 22
+adapter speed 1000
+
+# Transport
+transport select jtag
+
+# Target: Xilinx Artix-7 XC7A100T
+set _CHIPNAME xc7a100t
+jtag newtap $_CHIPNAME tap -irlen 6 -expected-id 0x13631093
+
+# Init
+init
+scan_chain
+```
+
+## GPIO Pin Configuration
+
+Use the `rp1_pio_jtag jtag_nums` command with BCM GPIO numbers:
+
+```tcl
+# rp1_pio_jtag jtag_nums <TCK> <TMS> <TDI> <TDO>
+rp1_pio_jtag jtag_nums 4 17 27 22
+```
+
+Optional reset lines:
+
+```tcl
+rp1_pio_jtag srst_num <gpio>
+rp1_pio_jtag trst_num <gpio>
+```
+
+For NeTV2 default wiring: TCK=GPIO4, TMS=GPIO17, TDI=GPIO27, TDO=GPIO22.
+
+## Integration Script
+
+`integrate.py` automates all source patches:
+
+```bash
+python3 integrate.py /path/to/openocd
+```
+
+It patches:
+- `src/jtag/interfaces.c` (extern + driver array entry)
+- `configure.ac` (enable option + pkg-config check)
+- `src/jtag/drivers/Makefile.am` (source file)
+
+The script is idempotent — safe to run multiple times.
+
+## Architecture
+
+This is a **non-bitbang** driver. Unlike `linuxgpiod` or `sysfsgpio` which
+toggle GPIO pins one-at-a-time per TCK cycle, this driver uses librp1jtag
+which programs the RP1's PIO state machine to shift data autonomously:
+
+| OpenOCD Command | librp1jtag Call | Notes |
+|---|---|---|
+| `JTAG_SCAN` | `rp1_jtag_shift(bits, tms, tdi, tdo)` | Bulk shift with auto TMS |
+| `JTAG_RUNTEST` | `rp1_jtag_toggle_clk(cycles, 0, 0)` | Clock in Run-Test/Idle |
+| `JTAG_STABLECLOCKS` | `rp1_jtag_toggle_clk(cycles, tms, 0)` | Clock in stable state |
+| `JTAG_TLR_RESET` | `rp1_jtag_shift(len, tms_path, ...)` | Navigate TAP states |
+| `JTAG_PATHMOVE` | `rp1_jtag_shift(len, tms_seq, ...)` | Explicit state path |
+| `JTAG_TMS` | `rp1_jtag_shift(len, tms_bits, ...)` | Raw TMS sequence |
+| `JTAG_RESET` | `rp1_jtag_reset(srst, trst)` | Assert/deassert resets |
+| Speed control | `rp1_jtag_set_freq(hz)` | kHz from `adapter speed` |
+
+## Performance
+
+With word-by-word PIO interleaving (Phase 1):
+- ~88 kB/s throughput (~18x faster than sysfsgpio)
+- Bypasses per-bit PCIe round-trip latency

--- a/drivers/openocd/integrate.py
+++ b/drivers/openocd/integrate.py
@@ -7,10 +7,13 @@ Usage:
 
 This script:
   1. Copies rp1_pio_jtag.c into src/jtag/drivers/
-  2. Patches src/jtag/interfaces.c to register the driver
-  3. Patches src/jtag/interfaces.h (or interface.h) to add the extern declaration
-  4. Patches configure.ac to add --enable-rp1-pio-jtag option
-  5. Patches src/jtag/drivers/Makefile.am to build the driver
+  2. Patches configure.ac to add m4 adapter definition, PKG_CHECK, AC_ARG_ENABLE,
+     PROCESS_ADAPTERS, USE_LIBRP1JTAG conditional, and summary
+  3. Patches src/jtag/drivers/Makefile.am to build the driver
+  4. Patches src/jtag/interface.h to add extern declaration
+  5. Patches src/jtag/interfaces.c to register the driver
+
+The script is idempotent — safe to run multiple times.
 
 SPDX-License-Identifier: Apache-2.0
 """
@@ -19,18 +22,16 @@ import sys
 import shutil
 from pathlib import Path
 
-ALREADY_APPLIED = "rp1_pio_jtag"
+MARKER = "rp1_pio_jtag"
 
 
 def insert_before(content: str, anchor: str, block: str, marker: str) -> str:
     """Insert block BEFORE the first occurrence of anchor."""
-    if ALREADY_APPLIED in content and ALREADY_APPLIED in block:
-        # Check if this specific patch is already applied
-        lines = block.strip().split('\n')
-        key_line = lines[1] if len(lines) > 1 else lines[0]
-        if key_line.strip() in content:
-            print(f"  {marker}: already applied, skipping")
-            return content
+    # Skip if block's key content is already present
+    key_lines = [l.strip() for l in block.strip().split('\n') if l.strip()]
+    if key_lines and any(l in content for l in key_lines[1:2]):
+        print(f"  {marker}: already applied, skipping")
+        return content
     idx = content.find(anchor)
     if idx < 0:
         print(f"  ERROR: {marker}: anchor not found")
@@ -43,7 +44,8 @@ def insert_before(content: str, anchor: str, block: str, marker: str) -> str:
 
 def insert_after(content: str, anchor: str, block: str, marker: str) -> str:
     """Insert block AFTER the first occurrence of anchor."""
-    if block.strip().split('\n')[0].strip() in content:
+    key_lines = [l.strip() for l in block.strip().split('\n') if l.strip()]
+    if key_lines and key_lines[0] in content:
         print(f"  {marker}: already applied, skipping")
         return content
     idx = content.find(anchor)
@@ -53,20 +55,6 @@ def insert_after(content: str, anchor: str, block: str, marker: str) -> str:
         sys.exit(1)
     insert_pos = idx + len(anchor)
     content = content[:insert_pos] + block + content[insert_pos:]
-    print(f"  {marker}: applied")
-    return content
-
-
-def replace_once(content: str, old: str, new: str, marker: str) -> str:
-    """Replace first occurrence of old with new."""
-    if new in content:
-        print(f"  {marker}: already applied, skipping")
-        return content
-    if old not in content:
-        print(f"  ERROR: {marker}: text not found")
-        print(f"         Looking for: {old[:80]!r}...")
-        sys.exit(1)
-    content = content.replace(old, new, 1)
     print(f"  {marker}: applied")
     return content
 
@@ -91,106 +79,143 @@ def main() -> None:
     shutil.copy2(script_dir / src_file, drivers_dir / src_file)
     print(f"  Copied {src_file} -> src/jtag/drivers/{src_file}")
 
-    # 2. Patch interfaces.c — add to driver list
+    # ---- 2. Patch configure.ac ----
+    print("\nPatching configure.ac...")
+    configure_ac = ocd_dir / "configure.ac"
+    ca = configure_ac.read_text()
+
+    # 2a. Add m4_define for LIBRP1JTAG_ADAPTERS after LIBGPIOD_ADAPTERS
+    ca = insert_after(
+        ca,
+        "m4_define([LIBGPIOD_ADAPTERS],\n"
+        "\t[[[linuxgpiod], [Linux GPIO bitbang through libgpiod], [LINUXGPIOD]]])\n",
+        "\nm4_define([LIBRP1JTAG_ADAPTERS],\n"
+        "\t[[[rp1_pio_jtag], [RP1 PIO JTAG for Raspberry Pi 5], [RP1_PIO_JTAG]]])\n",
+        "configure.ac m4_define",
+    )
+
+    # 2b. Add to AC_ARG_ADAPTERS (first group, default=auto)
+    # Insert after LIBGPIOD_ADAPTERS in the AC_ARG_ADAPTERS call
+    ca = insert_after(
+        ca,
+        "  LIBGPIOD_ADAPTERS,\n",
+        "  LIBRP1JTAG_ADAPTERS,\n",
+        "configure.ac AC_ARG_ADAPTERS",
+    )
+
+    # 2c. Add PKG_CHECK_MODULES for librp1jtag after libjaylink check
+    ca = insert_after(
+        ca,
+        "PKG_CHECK_MODULES([LIBJAYLINK], [libjaylink >= 0.2],\n"
+        "\t[use_libjaylink=yes], [use_libjaylink=no])\n",
+        "\nPKG_CHECK_MODULES([LIBRP1JTAG], [rp1jtag],\n"
+        "\t[use_librp1jtag=yes], [use_librp1jtag=no])\n",
+        "configure.ac PKG_CHECK_MODULES",
+    )
+
+    # 2d. Add PROCESS_ADAPTERS after LIBGPIOD_ADAPTERS processing
+    ca = insert_after(
+        ca,
+        "PROCESS_ADAPTERS([LIBGPIOD_ADAPTERS], "
+        "[\"x$use_libgpiod\" = \"xyes\"], [Linux libgpiod])\n",
+        "PROCESS_ADAPTERS([LIBRP1JTAG_ADAPTERS], "
+        "[\"x$use_librp1jtag\" = \"xyes\"], [librp1jtag])\n",
+        "configure.ac PROCESS_ADAPTERS",
+    )
+
+    # 2e. Add AM_CONDITIONAL for USE_LIBRP1JTAG after USE_LIBGPIOD
+    ca = insert_after(
+        ca,
+        "AM_CONDITIONAL([USE_LIBGPIOD], [test \"x$use_libgpiod\" = \"xyes\"])\n",
+        "AM_CONDITIONAL([USE_LIBRP1JTAG], [test \"x$use_librp1jtag\" = \"xyes\"])\n",
+        "configure.ac AM_CONDITIONAL",
+    )
+
+    # 2f. Add to configuration summary after LIBGPIOD_ADAPTERS
+    ca = insert_after(
+        ca,
+        "\tLIBGPIOD_ADAPTERS,\n",
+        "\tLIBRP1JTAG_ADAPTERS,\n",
+        "configure.ac summary",
+    )
+
+    configure_ac.write_text(ca)
+
+    # ---- 3. Patch src/jtag/drivers/Makefile.am ----
+    print("\nPatching src/jtag/drivers/Makefile.am...")
+    makefile_am = drivers_dir / "Makefile.am"
+    mf = makefile_am.read_text()
+
+    # Add USE_LIBRP1JTAG CPPFLAGS/LIBADD after USE_LIBGPIOD block
+    ca_block = (
+        "if USE_LIBGPIOD\n"
+        "%C%_libocdjtagdrivers_la_CPPFLAGS += $(LIBGPIOD_CFLAGS)\n"
+        "%C%_libocdjtagdrivers_la_LIBADD += $(LIBGPIOD_LIBS)\n"
+        "endif\n"
+    )
+    mf = insert_after(
+        mf,
+        ca_block,
+        "\nif USE_LIBRP1JTAG\n"
+        "%C%_libocdjtagdrivers_la_CPPFLAGS += $(LIBRP1JTAG_CFLAGS)\n"
+        "%C%_libocdjtagdrivers_la_LIBADD += $(LIBRP1JTAG_LIBS)\n"
+        "endif\n",
+        "Makefile.am CPPFLAGS/LIBADD",
+    )
+
+    # Add conditional source file after LINUXGPIOD DRIVERFILES
+    mf = insert_after(
+        mf,
+        "if LINUXGPIOD\n"
+        "DRIVERFILES += %D%/linuxgpiod.c\n"
+        "endif\n",
+        "if RP1_PIO_JTAG\n"
+        "DRIVERFILES += %D%/rp1_pio_jtag.c\n"
+        "endif\n",
+        "Makefile.am DRIVERFILES",
+    )
+
+    makefile_am.write_text(mf)
+
+    # ---- 4. Patch src/jtag/interface.h ----
+    print("\nPatching src/jtag/interface.h...")
+    interface_h = ocd_dir / "src" / "jtag" / "interface.h"
+    ih = interface_h.read_text()
+
+    # Add extern declaration in alphabetical order (after remote_bitbang)
+    ih = insert_after(
+        ih,
+        "extern struct adapter_driver remote_bitbang_adapter_driver;\n",
+        "extern struct adapter_driver rp1_pio_jtag_adapter_driver;\n",
+        "interface.h extern",
+    )
+
+    interface_h.write_text(ih)
+
+    # ---- 5. Patch src/jtag/interfaces.c ----
     print("\nPatching src/jtag/interfaces.c...")
     interfaces_c = ocd_dir / "src" / "jtag" / "interfaces.c"
     ic = interfaces_c.read_text()
 
-    # Add extern declaration near other externs
-    # Look for the linuxgpiod extern as anchor
-    ic = insert_before(
+    # Add driver entry after remote_bitbang (alphabetical order)
+    ic = insert_after(
         ic,
-        '#if BUILD_LINUXGPIOD == 1\n',
-        '#if BUILD_RP1_PIO_JTAG == 1\n'
-        'extern struct adapter_driver rp1_pio_jtag_adapter_driver;\n'
-        '#endif\n',
-        "interfaces.c extern",
-    )
-
-    # Add to adapter_drivers array
-    ic = insert_before(
-        ic,
-        '#if BUILD_LINUXGPIOD == 1\n'
-        '\t&linuxgpiod_adapter_driver,\n'
-        '#endif\n',
-        '#if BUILD_RP1_PIO_JTAG == 1\n'
-        '\t&rp1_pio_jtag_adapter_driver,\n'
-        '#endif\n',
+        "#if BUILD_REMOTE_BITBANG == 1\n"
+        "\t\t&remote_bitbang_adapter_driver,\n"
+        "#endif\n",
+        "#if BUILD_RP1_PIO_JTAG == 1\n"
+        "\t\t&rp1_pio_jtag_adapter_driver,\n"
+        "#endif\n",
         "interfaces.c array entry",
     )
 
     interfaces_c.write_text(ic)
 
-    # 3. Patch configure.ac — add --enable-rp1-pio-jtag option
-    print("\nPatching configure.ac...")
-    configure_ac = ocd_dir / "configure.ac"
-    ca = configure_ac.read_text()
-
-    # Add AC_ARG_ENABLE and build conditional near linuxgpiod
-    ca = insert_before(
-        ca,
-        'AC_ARG_ENABLE([linuxgpiod],',
-        'AC_ARG_ENABLE([rp1_pio_jtag],\n'
-        '  AS_HELP_STRING([--enable-rp1-pio-jtag],\n'
-        '    [Enable RP1 PIO JTAG adapter driver for Raspberry Pi 5 (default: no)]),\n'
-        '  [build_rp1_pio_jtag=$enableval], [build_rp1_pio_jtag=no])\n'
-        '\n',
-        "configure.ac AC_ARG_ENABLE",
-    )
-
-    # Add PKG_CHECK and AM_CONDITIONAL near linuxgpiod's
-    # Find the linuxgpiod build conditional block
-    linuxgpiod_conditional = 'AM_CONDITIONAL([LINUXGPIOD]'
-    if linuxgpiod_conditional in ca:
-        ca = insert_before(
-            ca,
-            linuxgpiod_conditional,
-            'AS_IF([test "x$build_rp1_pio_jtag" = "xyes"], [\n'
-            '  PKG_CHECK_MODULES([LIBRP1JTAG], [rp1jtag], [\n'
-            '    AC_DEFINE([BUILD_RP1_PIO_JTAG], [1], [Build RP1 PIO JTAG driver])\n'
-            '  ], [\n'
-            '    PKG_CHECK_MODULES([LIBRP1JTAG], [librp1jtag], [\n'
-            '      AC_DEFINE([BUILD_RP1_PIO_JTAG], [1], [Build RP1 PIO JTAG driver])\n'
-            '    ], [\n'
-            '      AC_MSG_ERROR([librp1jtag not found. Install from https://github.com/mithro/rp1-jtag])\n'
-            '    ])\n'
-            '  ])\n'
-            '], [\n'
-            '  build_rp1_pio_jtag=no\n'
-            '])\n'
-            'AM_CONDITIONAL([RP1_PIO_JTAG], [test "x$build_rp1_pio_jtag" = "xyes"])\n'
-            '\n',
-            "configure.ac AM_CONDITIONAL",
-        )
-    else:
-        print("  WARNING: Could not find AM_CONDITIONAL anchor for linuxgpiod")
-        print("  You may need to manually add the AM_CONDITIONAL for RP1_PIO_JTAG")
-
-    configure_ac.write_text(ca)
-
-    # 4. Patch src/jtag/drivers/Makefile.am — add source file
-    print("\nPatching src/jtag/drivers/Makefile.am...")
-    makefile_am = drivers_dir / "Makefile.am"
-    mf = makefile_am.read_text()
-
-    # Add conditional source near linuxgpiod
-    mf = insert_before(
-        mf,
-        'if LINUXGPIOD\n',
-        'if RP1_PIO_JTAG\n'
-        'DRIVERFILES += %D%/rp1_pio_jtag.c\n'
-        'endif\n\n',
-        "Makefile.am DRIVERFILES",
-    )
-
-    # Add include/link flags if needed
-    if 'RP1_PIO_JTAG' not in mf.split('DRIVERFILES')[0]:
-        # Check if there's an AM_CFLAGS section we need to extend
-        pass
-
-    makefile_am.write_text(mf)
-
-    print("\nDone! To build OpenOCD with rp1_pio_jtag support:")
+    print("\n" + "=" * 60)
+    print("Integration complete!")
+    print("=" * 60)
+    print()
+    print("To build OpenOCD with rp1_pio_jtag support:")
     print(f"  cd {ocd_dir}")
     print("  ./bootstrap")
     print("  ./configure --enable-rp1-pio-jtag")

--- a/drivers/openocd/integrate.py
+++ b/drivers/openocd/integrate.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+Integrate rp1_pio_jtag adapter driver into an OpenOCD source tree.
+
+Usage:
+    python3 integrate.py /path/to/openocd
+
+This script:
+  1. Copies rp1_pio_jtag.c into src/jtag/drivers/
+  2. Patches src/jtag/interfaces.c to register the driver
+  3. Patches src/jtag/interfaces.h (or interface.h) to add the extern declaration
+  4. Patches configure.ac to add --enable-rp1-pio-jtag option
+  5. Patches src/jtag/drivers/Makefile.am to build the driver
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import sys
+import shutil
+from pathlib import Path
+
+ALREADY_APPLIED = "rp1_pio_jtag"
+
+
+def insert_before(content: str, anchor: str, block: str, marker: str) -> str:
+    """Insert block BEFORE the first occurrence of anchor."""
+    if ALREADY_APPLIED in content and ALREADY_APPLIED in block:
+        # Check if this specific patch is already applied
+        lines = block.strip().split('\n')
+        key_line = lines[1] if len(lines) > 1 else lines[0]
+        if key_line.strip() in content:
+            print(f"  {marker}: already applied, skipping")
+            return content
+    idx = content.find(anchor)
+    if idx < 0:
+        print(f"  ERROR: {marker}: anchor not found")
+        print(f"         Looking for: {anchor[:80]!r}...")
+        sys.exit(1)
+    content = content[:idx] + block + content[idx:]
+    print(f"  {marker}: applied")
+    return content
+
+
+def insert_after(content: str, anchor: str, block: str, marker: str) -> str:
+    """Insert block AFTER the first occurrence of anchor."""
+    if block.strip().split('\n')[0].strip() in content:
+        print(f"  {marker}: already applied, skipping")
+        return content
+    idx = content.find(anchor)
+    if idx < 0:
+        print(f"  ERROR: {marker}: anchor not found")
+        print(f"         Looking for: {anchor[:80]!r}...")
+        sys.exit(1)
+    insert_pos = idx + len(anchor)
+    content = content[:insert_pos] + block + content[insert_pos:]
+    print(f"  {marker}: applied")
+    return content
+
+
+def replace_once(content: str, old: str, new: str, marker: str) -> str:
+    """Replace first occurrence of old with new."""
+    if new in content:
+        print(f"  {marker}: already applied, skipping")
+        return content
+    if old not in content:
+        print(f"  ERROR: {marker}: text not found")
+        print(f"         Looking for: {old[:80]!r}...")
+        sys.exit(1)
+    content = content.replace(old, new, 1)
+    print(f"  {marker}: applied")
+    return content
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} /path/to/openocd")
+        sys.exit(1)
+
+    ocd_dir = Path(sys.argv[1])
+    drivers_dir = ocd_dir / "src" / "jtag" / "drivers"
+    script_dir = Path(__file__).parent
+
+    if not drivers_dir.exists():
+        print(f"Error: {drivers_dir} not found. Is this an OpenOCD source tree?")
+        sys.exit(1)
+
+    print("Integrating rp1_pio_jtag adapter driver into OpenOCD...")
+
+    # 1. Copy driver file
+    src_file = "rp1_pio_jtag.c"
+    shutil.copy2(script_dir / src_file, drivers_dir / src_file)
+    print(f"  Copied {src_file} -> src/jtag/drivers/{src_file}")
+
+    # 2. Patch interfaces.c — add to driver list
+    print("\nPatching src/jtag/interfaces.c...")
+    interfaces_c = ocd_dir / "src" / "jtag" / "interfaces.c"
+    ic = interfaces_c.read_text()
+
+    # Add extern declaration near other externs
+    # Look for the linuxgpiod extern as anchor
+    ic = insert_before(
+        ic,
+        '#if BUILD_LINUXGPIOD == 1\n',
+        '#if BUILD_RP1_PIO_JTAG == 1\n'
+        'extern struct adapter_driver rp1_pio_jtag_adapter_driver;\n'
+        '#endif\n',
+        "interfaces.c extern",
+    )
+
+    # Add to adapter_drivers array
+    ic = insert_before(
+        ic,
+        '#if BUILD_LINUXGPIOD == 1\n'
+        '\t&linuxgpiod_adapter_driver,\n'
+        '#endif\n',
+        '#if BUILD_RP1_PIO_JTAG == 1\n'
+        '\t&rp1_pio_jtag_adapter_driver,\n'
+        '#endif\n',
+        "interfaces.c array entry",
+    )
+
+    interfaces_c.write_text(ic)
+
+    # 3. Patch configure.ac — add --enable-rp1-pio-jtag option
+    print("\nPatching configure.ac...")
+    configure_ac = ocd_dir / "configure.ac"
+    ca = configure_ac.read_text()
+
+    # Add AC_ARG_ENABLE and build conditional near linuxgpiod
+    ca = insert_before(
+        ca,
+        'AC_ARG_ENABLE([linuxgpiod],',
+        'AC_ARG_ENABLE([rp1_pio_jtag],\n'
+        '  AS_HELP_STRING([--enable-rp1-pio-jtag],\n'
+        '    [Enable RP1 PIO JTAG adapter driver for Raspberry Pi 5 (default: no)]),\n'
+        '  [build_rp1_pio_jtag=$enableval], [build_rp1_pio_jtag=no])\n'
+        '\n',
+        "configure.ac AC_ARG_ENABLE",
+    )
+
+    # Add PKG_CHECK and AM_CONDITIONAL near linuxgpiod's
+    # Find the linuxgpiod build conditional block
+    linuxgpiod_conditional = 'AM_CONDITIONAL([LINUXGPIOD]'
+    if linuxgpiod_conditional in ca:
+        ca = insert_before(
+            ca,
+            linuxgpiod_conditional,
+            'AS_IF([test "x$build_rp1_pio_jtag" = "xyes"], [\n'
+            '  PKG_CHECK_MODULES([LIBRP1JTAG], [rp1jtag], [\n'
+            '    AC_DEFINE([BUILD_RP1_PIO_JTAG], [1], [Build RP1 PIO JTAG driver])\n'
+            '  ], [\n'
+            '    PKG_CHECK_MODULES([LIBRP1JTAG], [librp1jtag], [\n'
+            '      AC_DEFINE([BUILD_RP1_PIO_JTAG], [1], [Build RP1 PIO JTAG driver])\n'
+            '    ], [\n'
+            '      AC_MSG_ERROR([librp1jtag not found. Install from https://github.com/mithro/rp1-jtag])\n'
+            '    ])\n'
+            '  ])\n'
+            '], [\n'
+            '  build_rp1_pio_jtag=no\n'
+            '])\n'
+            'AM_CONDITIONAL([RP1_PIO_JTAG], [test "x$build_rp1_pio_jtag" = "xyes"])\n'
+            '\n',
+            "configure.ac AM_CONDITIONAL",
+        )
+    else:
+        print("  WARNING: Could not find AM_CONDITIONAL anchor for linuxgpiod")
+        print("  You may need to manually add the AM_CONDITIONAL for RP1_PIO_JTAG")
+
+    configure_ac.write_text(ca)
+
+    # 4. Patch src/jtag/drivers/Makefile.am — add source file
+    print("\nPatching src/jtag/drivers/Makefile.am...")
+    makefile_am = drivers_dir / "Makefile.am"
+    mf = makefile_am.read_text()
+
+    # Add conditional source near linuxgpiod
+    mf = insert_before(
+        mf,
+        'if LINUXGPIOD\n',
+        'if RP1_PIO_JTAG\n'
+        'DRIVERFILES += %D%/rp1_pio_jtag.c\n'
+        'endif\n\n',
+        "Makefile.am DRIVERFILES",
+    )
+
+    # Add include/link flags if needed
+    if 'RP1_PIO_JTAG' not in mf.split('DRIVERFILES')[0]:
+        # Check if there's an AM_CFLAGS section we need to extend
+        pass
+
+    makefile_am.write_text(mf)
+
+    print("\nDone! To build OpenOCD with rp1_pio_jtag support:")
+    print(f"  cd {ocd_dir}")
+    print("  ./bootstrap")
+    print("  ./configure --enable-rp1-pio-jtag")
+    print("  make -j$(nproc)")
+    print()
+    print("Example OpenOCD config (netv2.cfg):")
+    print("  adapter driver rp1_pio_jtag")
+    print("  rp1_pio_jtag jtag_nums 4 17 27 22")
+    print("  adapter speed 1000")
+    print("  transport select jtag")
+
+
+if __name__ == "__main__":
+    main()

--- a/drivers/openocd/integrate.py
+++ b/drivers/openocd/integrate.py
@@ -27,9 +27,8 @@ MARKER = "rp1_pio_jtag"
 
 def insert_before(content: str, anchor: str, block: str, marker: str) -> str:
     """Insert block BEFORE the first occurrence of anchor."""
-    # Skip if block's key content is already present
-    key_lines = [l.strip() for l in block.strip().split('\n') if l.strip()]
-    if key_lines and any(l in content for l in key_lines[1:2]):
+    # Idempotency: the exact block already sits in front of the anchor.
+    if block + anchor in content:
         print(f"  {marker}: already applied, skipping")
         return content
     idx = content.find(anchor)
@@ -44,8 +43,11 @@ def insert_before(content: str, anchor: str, block: str, marker: str) -> str:
 
 def insert_after(content: str, anchor: str, block: str, marker: str) -> str:
     """Insert block AFTER the first occurrence of anchor."""
-    key_lines = [l.strip() for l in block.strip().split('\n') if l.strip()]
-    if key_lines and key_lines[0] in content:
+    # Idempotency: the exact block already follows the anchor. Matching a
+    # single stripped line is not enough: the AC_ARG_ADAPTERS and summary
+    # entries are the same text at different indentation, so the second
+    # was wrongly skipped once the first had been applied.
+    if anchor + block in content:
         print(f"  {marker}: already applied, skipping")
         return content
     idx = content.find(anchor)

--- a/drivers/openocd/netv2_35t.cfg
+++ b/drivers/openocd/netv2_35t.cfg
@@ -1,0 +1,17 @@
+# NeTV2 FPGA board via RP1 PIO JTAG on Raspberry Pi 5
+# Target: Xilinx Artix-7 XC7A35T (IDCODE 0x0362D093)
+
+# Adapter
+adapter driver rp1_pio_jtag
+rp1_pio_jtag jtag_nums 4 17 27 22
+adapter speed 1000
+
+# Transport
+transport select jtag
+
+# Target: Xilinx Artix-7 (using OpenOCD's built-in XC7 config)
+source [find cpld/xilinx-xc7.cfg]
+
+# Init
+init
+scan_chain

--- a/drivers/openocd/netv2_35t.cfg
+++ b/drivers/openocd/netv2_35t.cfg
@@ -9,9 +9,8 @@ adapter speed 1000
 # Transport
 transport select jtag
 
+# No reset lines on this setup
+reset_config none
+
 # Target: Xilinx Artix-7 (using OpenOCD's built-in XC7 config)
 source [find cpld/xilinx-xc7.cfg]
-
-# Init
-init
-scan_chain

--- a/drivers/openocd/netv2_35t_spi.cfg
+++ b/drivers/openocd/netv2_35t_spi.cfg
@@ -1,0 +1,30 @@
+# NeTV2 FPGA board - SPI flash via JTAG (bscan_spi proxy)
+# Target: Xilinx Artix-7 XC7A35T on RP1 PIO JTAG
+#
+# Usage:
+#   sudo openocd -s tcl -f netv2_35t_spi.cfg
+#
+# This loads the bscan_spi proxy bitstream into the FPGA, then
+# probes the SPI flash connected to the FPGA.
+
+# Adapter
+adapter driver rp1_pio_jtag
+rp1_pio_jtag jtag_nums 4 17 27 22
+adapter speed 1000
+
+# Transport
+transport select jtag
+
+# No reset lines on this setup
+reset_config none
+
+# Target: Xilinx Artix-7
+source [find cpld/xilinx-xc7.cfg]
+
+# JTAG-to-SPI proxy (creates testee target + flash bank)
+source [find cpld/jtagspi.cfg]
+
+# Load bscan_spi proxy and probe SPI flash using PLD name (not number)
+proc netv2_spi_init {proxy_bit} {
+	jtagspi_init $_CHIPNAME.pld $proxy_bit
+}

--- a/drivers/openocd/netv2_spiflash.sh
+++ b/drivers/openocd/netv2_spiflash.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# netv2_spiflash.sh — SPI flash utility for NeTV2 via RP1 PIO JTAG
+#
+# Scans for SPI flash using bscan_spi proxy bitstream, then optionally
+# writes a bitstream to flash at offset 0 and reboots the FPGA.
+#
+# Usage:
+#   sudo ./netv2_spiflash.sh scan
+#   sudo ./netv2_spiflash.sh flash <bitstream.bin>
+#   sudo ./netv2_spiflash.sh read  <output.bin> [offset] [size]
+#
+# Requires: OpenOCD built with --enable-rp1-pio-jtag, bscan_spi_xc7a35t.bit
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# --- Configuration ---
+OPENOCD="${OPENOCD:-/home/k8s/openocd/src/openocd}"
+OPENOCD_TCL="${OPENOCD_TCL:-/home/k8s/openocd/tcl}"
+BSCAN_BIT="${BSCAN_BIT:-/home/k8s/netv2mvp-scripts/bscan_spi_xc7a35t.bit}"
+CFG="${SCRIPT_DIR}/netv2_35t_spi.cfg"
+
+# --- Helpers ---
+die()  { echo "ERROR: $*" >&2; exit 1; }
+info() { echo ">>> $*"; }
+
+cleanup_pio() {
+    local pids
+    pids="$(sudo lsof -t /dev/pio0 2>/dev/null || true)"
+    if [ -n "$pids" ]; then
+        info "Killing stale PIO processes: $pids"
+        sudo kill -9 $pids 2>/dev/null || true
+        sleep 0.3
+    fi
+}
+
+run_openocd() {
+    # Run OpenOCD with the SPI config and arbitrary -c commands
+    sudo "$OPENOCD" -s "$OPENOCD_TCL" -f "$CFG" "$@" 2>&1
+}
+
+# --- Preflight checks ---
+[ -x "$OPENOCD" ]  || die "OpenOCD not found at $OPENOCD"
+[ -f "$BSCAN_BIT" ] || die "bscan_spi bitstream not found at $BSCAN_BIT"
+[ -f "$CFG" ]       || die "Config file not found at $CFG"
+[ "$(id -u)" -eq 0 ] || die "Must run as root (sudo)"
+
+# --- Commands ---
+cmd_scan() {
+    info "Scanning SPI flash on NeTV2 (XC7A35T) via RP1 PIO JTAG..."
+    cleanup_pio
+    run_openocd \
+        -c "init" \
+        -c "jtagspi_init xc7.pld $BSCAN_BIT" \
+        -c "flash info 0" \
+        -c "flash list" \
+        -c "shutdown"
+}
+
+cmd_flash() {
+    local bitstream="$1"
+    [ -f "$bitstream" ] || die "Bitstream file not found: $bitstream"
+
+    local size
+    size="$(stat -c%s "$bitstream")"
+    info "Flashing $bitstream ($size bytes) to SPI flash at offset 0..."
+    info "  bscan_spi: $BSCAN_BIT"
+
+    cleanup_pio
+    run_openocd \
+        -c "init" \
+        -c "jtagspi_init xc7.pld $BSCAN_BIT" \
+        -c "jtagspi_program $bitstream 0" \
+        -c "virtex2 refresh xc7.pld" \
+        -c "shutdown"
+
+    info "Flash complete. FPGA rebooted from SPI."
+}
+
+cmd_read() {
+    local output="$1"
+    local offset="${2:-0}"
+    local size="${3:-256}"
+
+    info "Reading $size bytes from SPI flash at offset $offset..."
+    cleanup_pio
+    run_openocd \
+        -c "init" \
+        -c "jtagspi_init xc7.pld $BSCAN_BIT" \
+        -c "flash read_bank 0 $output $offset $size" \
+        -c "shutdown"
+
+    info "Read complete: $output"
+}
+
+# --- Main ---
+case "${1:-}" in
+    scan)
+        cmd_scan
+        ;;
+    flash)
+        [ -n "${2:-}" ] || die "Usage: $0 flash <bitstream.bin>"
+        cmd_flash "$2"
+        ;;
+    read)
+        [ -n "${2:-}" ] || die "Usage: $0 read <output.bin> [offset] [size]"
+        cmd_read "$2" "${3:-0}" "${4:-256}"
+        ;;
+    *)
+        echo "Usage: $0 {scan|flash|read} [args...]"
+        echo ""
+        echo "Commands:"
+        echo "  scan                          Detect SPI flash via JTAG"
+        echo "  flash <bitstream.bin>         Erase+write+verify bitstream to SPI"
+        echo "  read  <out.bin> [off] [size]  Read bytes from SPI flash"
+        exit 1
+        ;;
+esac

--- a/drivers/openocd/rp1_pio_jtag.c
+++ b/drivers/openocd/rp1_pio_jtag.c
@@ -1,0 +1,571 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * rp1_pio_jtag.c - OpenOCD adapter driver for RP1 PIO JTAG
+ *
+ * Copyright (C) 2025 Tim Ansell <me@mith.ro>
+ *
+ * Uses librp1jtag for high-speed JTAG via the Raspberry Pi 5's RP1 PIO
+ * subsystem.  This is a non-bitbang driver: the PIO engine shifts data
+ * autonomously while the host supplies TDI/TMS vectors and collects TDO,
+ * bypassing the per-bit PCIe round-trip that makes linuxgpiod/sysfsgpio
+ * slow on RPi 5.
+ *
+ * Style: C, snake_case, tab indent, LOG_INFO/LOG_ERROR, ERROR_OK returns
+ * (matching OpenOCD conventions).
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <jtag/adapter.h>
+#include <jtag/interface.h>
+#include <jtag/commands.h>
+#include <transport/transport.h>
+#include <helper/bits.h>
+#include <helper/log.h>
+#include <helper/time_support.h>
+
+#include <rp1_jtag.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+/* Forward declarations */
+static int rp1_pio_jtag_reset_handler(int trst, int srst);
+
+/* ---- State ---- */
+
+static rp1_jtag_t *rp1_dev;
+static int speed_khz;
+
+static int tck_gpio = -1;
+static int tms_gpio = -1;
+static int tdi_gpio = -1;
+static int tdo_gpio = -1;
+static int srst_gpio = -1;
+static int trst_gpio = -1;
+
+/* ---- TAP state helpers ---- */
+
+/*
+ * Build a TMS bit-vector that walks from cur_state to goal_state using
+ * the standard shortest-path lookup.  Returns the number of TMS bits.
+ */
+static int tms_seq_for_state(enum tap_state cur, enum tap_state goal,
+			     uint8_t *tms_buf, int max_bits)
+{
+	int len = tap_get_tms_path_len(cur, goal);
+	uint32_t tms_bits = tap_get_tms_path(cur, goal);
+
+	if (len > max_bits) {
+		LOG_ERROR("rp1_pio_jtag: TMS path too long (%d > %d)",
+			  len, max_bits);
+		return -1;
+	}
+
+	memset(tms_buf, 0, DIV_ROUND_UP(len, 8));
+	for (int i = 0; i < len; i++) {
+		if (tms_bits & (1u << i))
+			tms_buf[i / 8] |= (1u << (i % 8));
+	}
+	return len;
+}
+
+/*
+ * Shift a short TMS sequence (with TDI=0) and update the TAP state.
+ */
+static int rp1_pio_state_move(enum tap_state goal)
+{
+	uint8_t tms_buf[2];
+	uint8_t tdi_buf[2] = {0, 0};
+	enum tap_state cur = tap_get_state();
+
+	if (cur == goal)
+		return ERROR_OK;
+
+	int len = tms_seq_for_state(cur, goal, tms_buf, 16);
+	if (len < 0)
+		return ERROR_FAIL;
+
+	int ret = rp1_jtag_shift(rp1_dev, len, tms_buf, tdi_buf, NULL);
+	if (ret < 0) {
+		LOG_ERROR("rp1_pio_jtag: state_move shift failed (%d)", ret);
+		return ERROR_FAIL;
+	}
+
+	tap_set_state(goal);
+	return ERROR_OK;
+}
+
+/* ---- Command handlers ---- */
+
+static int rp1_pio_handle_scan(struct scan_command *cmd)
+{
+	uint8_t *tdi_buf = NULL;
+	int scan_bits;
+	int retval;
+
+	/* Navigate to Shift-IR or Shift-DR */
+	enum tap_state shift_state = cmd->ir_scan ? TAP_IRSHIFT : TAP_DRSHIFT;
+	retval = rp1_pio_state_move(shift_state);
+	if (retval != ERROR_OK)
+		return retval;
+
+	/* Let OpenOCD pack all scan fields into a flat TDI buffer */
+	scan_bits = jtag_build_buffer(cmd, &tdi_buf);
+	if (scan_bits == 0) {
+		free(tdi_buf);
+		return ERROR_OK;
+	}
+
+	int num_bytes = DIV_ROUND_UP(scan_bits, 8);
+
+	/* Build TMS vector: all 0s, last bit = 1 to exit Shift state */
+	uint8_t *tms = calloc(num_bytes, 1);
+	if (!tms) {
+		free(tdi_buf);
+		return ERROR_FAIL;
+	}
+	tms[(scan_bits - 1) / 8] |= (1u << ((scan_bits - 1) % 8));
+
+	/* TDO capture buffer */
+	uint8_t *tdo = calloc(num_bytes, 1);
+	if (!tdo) {
+		free(tms);
+		free(tdi_buf);
+		return ERROR_FAIL;
+	}
+
+	/* Bulk shift via librp1jtag */
+	int ret = rp1_jtag_shift(rp1_dev, scan_bits, tms, tdi_buf, tdo);
+	if (ret < 0) {
+		LOG_ERROR("rp1_pio_jtag: scan shift failed (%d)", ret);
+		free(tdo);
+		free(tms);
+		free(tdi_buf);
+		return ERROR_FAIL;
+	}
+
+	/* After shifting with TMS=1 on last bit, TAP is in Exit1-xR */
+	enum tap_state exit_state = cmd->ir_scan ? TAP_IREXIT1 : TAP_DREXIT1;
+	tap_set_state(exit_state);
+
+	/* Copy TDO data back through OpenOCD's scan field machinery */
+	retval = jtag_read_buffer(tdo, cmd);
+
+	free(tdo);
+	free(tms);
+	free(tdi_buf);
+
+	if (retval != ERROR_OK)
+		return retval;
+
+	/* Move to the end state requested by the command */
+	if (tap_get_state() != cmd->end_state)
+		retval = rp1_pio_state_move(cmd->end_state);
+
+	return retval;
+}
+
+static int rp1_pio_handle_runtest(unsigned int num_cycles,
+				  enum tap_state end_state)
+{
+	int retval;
+
+	/* Move to Run-Test/Idle first */
+	retval = rp1_pio_state_move(TAP_IDLE);
+	if (retval != ERROR_OK)
+		return retval;
+
+	/* Clock with TMS=0, TDI=0 in Run-Test/Idle */
+	if (num_cycles > 0) {
+		int ret = rp1_jtag_toggle_clk(rp1_dev, num_cycles, false, false);
+		if (ret < 0) {
+			LOG_ERROR("rp1_pio_jtag: runtest toggle_clk failed (%d)", ret);
+			return ERROR_FAIL;
+		}
+	}
+
+	/* Move to end state if different */
+	if (end_state != TAP_IDLE)
+		retval = rp1_pio_state_move(end_state);
+
+	return retval;
+}
+
+static int rp1_pio_handle_stableclocks(unsigned int num_cycles)
+{
+	/*
+	 * Clock in the current stable state.  TMS stays the same as the
+	 * value that keeps us in this state.
+	 */
+	enum tap_state state = tap_get_state();
+	bool tms_value;
+
+	switch (state) {
+	case TAP_IDLE:
+	case TAP_DRPAUSE:
+	case TAP_IRPAUSE:
+		tms_value = false;
+		break;
+	case TAP_RESET:
+		tms_value = true;
+		break;
+	default:
+		LOG_ERROR("rp1_pio_jtag: stableclocks in non-stable state %s",
+			  tap_state_name(state));
+		return ERROR_FAIL;
+	}
+
+	if (num_cycles > 0) {
+		int ret = rp1_jtag_toggle_clk(rp1_dev, num_cycles,
+					       tms_value, false);
+		if (ret < 0) {
+			LOG_ERROR("rp1_pio_jtag: stableclocks failed (%d)", ret);
+			return ERROR_FAIL;
+		}
+	}
+
+	return ERROR_OK;
+}
+
+static int rp1_pio_handle_pathmove(struct pathmove_command *cmd)
+{
+	/*
+	 * Walk an explicit sequence of TAP states.  Each transition is a
+	 * single TCK with the appropriate TMS value.
+	 */
+	int num_states = cmd->num_states;
+
+	if (num_states == 0)
+		return ERROR_OK;
+
+	int num_bytes = DIV_ROUND_UP(num_states, 8);
+	uint8_t *tms = calloc(num_bytes, 1);
+	uint8_t *tdi = calloc(num_bytes, 1);
+	if (!tms || !tdi) {
+		free(tms);
+		free(tdi);
+		return ERROR_FAIL;
+	}
+
+	enum tap_state cur = tap_get_state();
+
+	for (int i = 0; i < num_states; i++) {
+		enum tap_state next = cmd->path[i];
+
+		if (tap_state_transition(cur, false) == next) {
+			/* TMS=0 transitions to next */
+		} else if (tap_state_transition(cur, true) == next) {
+			tms[i / 8] |= (1u << (i % 8));
+		} else {
+			LOG_ERROR("rp1_pio_jtag: invalid path %s -> %s",
+				  tap_state_name(cur), tap_state_name(next));
+			free(tms);
+			free(tdi);
+			return ERROR_FAIL;
+		}
+
+		cur = next;
+	}
+
+	int ret = rp1_jtag_shift(rp1_dev, num_states, tms, tdi, NULL);
+	free(tms);
+	free(tdi);
+
+	if (ret < 0) {
+		LOG_ERROR("rp1_pio_jtag: pathmove shift failed (%d)", ret);
+		return ERROR_FAIL;
+	}
+
+	tap_set_state(cur);
+	return ERROR_OK;
+}
+
+static int rp1_pio_handle_tms(struct tms_command *cmd)
+{
+	int num_bits = cmd->num_bits;
+	int num_bytes = DIV_ROUND_UP(num_bits, 8);
+
+	uint8_t *tdi = calloc(num_bytes, 1);
+	if (!tdi)
+		return ERROR_FAIL;
+
+	int ret = rp1_jtag_shift(rp1_dev, num_bits, cmd->bits, tdi, NULL);
+	free(tdi);
+
+	if (ret < 0) {
+		LOG_ERROR("rp1_pio_jtag: TMS shift failed (%d)", ret);
+		return ERROR_FAIL;
+	}
+
+	/*
+	 * We must update the TAP state by replaying the TMS bits.
+	 * Walk through the TMS bits and let OpenOCD track state.
+	 */
+	enum tap_state cur = tap_get_state();
+	for (int i = 0; i < num_bits; i++) {
+		bool tms_bit = (cmd->bits[i / 8] >> (i % 8)) & 1;
+		cur = tap_state_transition(cur, tms_bit);
+	}
+	tap_set_state(cur);
+
+	return ERROR_OK;
+}
+
+/* ---- execute_queue ---- */
+
+static int rp1_pio_jtag_execute_queue(struct jtag_command *cmd_queue)
+{
+	struct jtag_command *cmd;
+	int retval = ERROR_OK;
+
+	for (cmd = cmd_queue; retval == ERROR_OK && cmd; cmd = cmd->next) {
+		switch (cmd->type) {
+		case JTAG_RESET:
+			retval = rp1_pio_jtag_reset_handler(
+				cmd->cmd.reset->trst,
+				cmd->cmd.reset->srst);
+			break;
+		case JTAG_RUNTEST:
+			retval = rp1_pio_handle_runtest(
+				cmd->cmd.runtest->num_cycles,
+				cmd->cmd.runtest->end_state);
+			break;
+		case JTAG_STABLECLOCKS:
+			retval = rp1_pio_handle_stableclocks(
+				cmd->cmd.stableclocks->num_cycles);
+			break;
+		case JTAG_TLR_RESET:
+			retval = rp1_pio_state_move(
+				cmd->cmd.statemove->end_state);
+			break;
+		case JTAG_PATHMOVE:
+			retval = rp1_pio_handle_pathmove(
+				cmd->cmd.pathmove);
+			break;
+		case JTAG_TMS:
+			retval = rp1_pio_handle_tms(cmd->cmd.tms);
+			break;
+		case JTAG_SLEEP:
+			jtag_sleep(cmd->cmd.sleep->us);
+			break;
+		case JTAG_SCAN:
+			retval = rp1_pio_handle_scan(cmd->cmd.scan);
+			break;
+		default:
+			LOG_ERROR("rp1_pio_jtag: unknown command type 0x%X",
+				  cmd->type);
+			retval = ERROR_FAIL;
+			break;
+		}
+	}
+	return retval;
+}
+
+/* ---- Reset ---- */
+
+static int rp1_pio_jtag_reset_handler(int trst, int srst)
+{
+	/*
+	 * OpenOCD convention: 1 = assert, 0 = deassert
+	 * librp1jtag convention: 0 = assert (active-low), 1 = deassert
+	 * Invert:
+	 */
+	int ret = rp1_jtag_reset(rp1_dev,
+				 srst ? 0 : 1,
+				 trst ? 0 : 1);
+	if (ret < 0) {
+		LOG_ERROR("rp1_pio_jtag: reset failed (%d)", ret);
+		return ERROR_FAIL;
+	}
+
+	if (trst)
+		tap_set_state(TAP_RESET);
+
+	return ERROR_OK;
+}
+
+/* ---- Speed ---- */
+
+static int rp1_pio_jtag_khz(int khz, int *jtag_speed)
+{
+	if (khz == 0) {
+		LOG_ERROR("rp1_pio_jtag: RTCK not supported");
+		return ERROR_FAIL;
+	}
+	*jtag_speed = khz;
+	return ERROR_OK;
+}
+
+static int rp1_pio_jtag_speed_div(int speed, int *khz)
+{
+	*khz = speed;
+	return ERROR_OK;
+}
+
+static int rp1_pio_jtag_speed(int speed)
+{
+	speed_khz = speed;
+	if (rp1_dev) {
+		int ret = rp1_jtag_set_freq(rp1_dev, speed * 1000);
+		if (ret < 0) {
+			LOG_ERROR("rp1_pio_jtag: failed to set freq %d kHz",
+				  speed);
+			return ERROR_FAIL;
+		}
+	}
+	return ERROR_OK;
+}
+
+/* ---- Lifecycle ---- */
+
+static int rp1_pio_jtag_init(void)
+{
+	LOG_INFO("rp1_pio_jtag: initializing RP1 PIO JTAG driver");
+
+	if (tck_gpio < 0 || tms_gpio < 0 || tdi_gpio < 0 || tdo_gpio < 0) {
+		LOG_ERROR("rp1_pio_jtag: GPIO pins not configured. "
+			  "Use: rp1_pio_jtag jtag_nums <tck> <tms> <tdi> <tdo>");
+		return ERROR_JTAG_INIT_FAILED;
+	}
+
+	rp1_jtag_pins_t pins = {
+		.tck  = tck_gpio,
+		.tms  = tms_gpio,
+		.tdi  = tdi_gpio,
+		.tdo  = tdo_gpio,
+		.srst = srst_gpio,
+		.trst = trst_gpio,
+	};
+
+	LOG_INFO("rp1_pio_jtag: TCK=%d TMS=%d TDI=%d TDO=%d SRST=%d TRST=%d",
+		 tck_gpio, tms_gpio, tdi_gpio, tdo_gpio, srst_gpio, trst_gpio);
+
+	rp1_dev = rp1_jtag_init(&pins);
+	if (!rp1_dev) {
+		LOG_ERROR("rp1_pio_jtag: failed to initialize librp1jtag. "
+			  "Check /dev/pio0 exists and permissions.");
+		return ERROR_JTAG_INIT_FAILED;
+	}
+
+	if (speed_khz > 0) {
+		rp1_jtag_set_freq(rp1_dev, speed_khz * 1000);
+		LOG_INFO("rp1_pio_jtag: clock set to %d kHz", speed_khz);
+	}
+
+	return ERROR_OK;
+}
+
+static int rp1_pio_jtag_quit(void)
+{
+	if (rp1_dev) {
+		rp1_jtag_close(rp1_dev);
+		rp1_dev = NULL;
+	}
+	LOG_INFO("rp1_pio_jtag: driver closed");
+	return ERROR_OK;
+}
+
+/* ---- Config commands ---- */
+
+COMMAND_HANDLER(rp1_pio_jtag_handle_jtag_nums)
+{
+	if (CMD_ARGC == 4) {
+		COMMAND_PARSE_NUMBER(int, CMD_ARGV[0], tck_gpio);
+		COMMAND_PARSE_NUMBER(int, CMD_ARGV[1], tms_gpio);
+		COMMAND_PARSE_NUMBER(int, CMD_ARGV[2], tdi_gpio);
+		COMMAND_PARSE_NUMBER(int, CMD_ARGV[3], tdo_gpio);
+	} else if (CMD_ARGC != 0) {
+		return ERROR_COMMAND_SYNTAX_ERROR;
+	}
+
+	command_print(CMD,
+		      "rp1_pio_jtag GPIO config: tck=%d tms=%d tdi=%d tdo=%d",
+		      tck_gpio, tms_gpio, tdi_gpio, tdo_gpio);
+	return ERROR_OK;
+}
+
+COMMAND_HANDLER(rp1_pio_jtag_handle_srst_num)
+{
+	if (CMD_ARGC == 1) {
+		COMMAND_PARSE_NUMBER(int, CMD_ARGV[0], srst_gpio);
+	} else if (CMD_ARGC != 0) {
+		return ERROR_COMMAND_SYNTAX_ERROR;
+	}
+
+	command_print(CMD, "rp1_pio_jtag SRST GPIO: %d", srst_gpio);
+	return ERROR_OK;
+}
+
+COMMAND_HANDLER(rp1_pio_jtag_handle_trst_num)
+{
+	if (CMD_ARGC == 1) {
+		COMMAND_PARSE_NUMBER(int, CMD_ARGV[0], trst_gpio);
+	} else if (CMD_ARGC != 0) {
+		return ERROR_COMMAND_SYNTAX_ERROR;
+	}
+
+	command_print(CMD, "rp1_pio_jtag TRST GPIO: %d", trst_gpio);
+	return ERROR_OK;
+}
+
+static const struct command_registration rp1_pio_jtag_subcommand_handlers[] = {
+	{
+		.name = "jtag_nums",
+		.handler = rp1_pio_jtag_handle_jtag_nums,
+		.mode = COMMAND_CONFIG,
+		.help = "Set GPIO numbers for JTAG signals (BCM numbering).",
+		.usage = "[tck tms tdi tdo]",
+	},
+	{
+		.name = "srst_num",
+		.handler = rp1_pio_jtag_handle_srst_num,
+		.mode = COMMAND_CONFIG,
+		.help = "Set GPIO number for SRST.",
+		.usage = "[gpio]",
+	},
+	{
+		.name = "trst_num",
+		.handler = rp1_pio_jtag_handle_trst_num,
+		.mode = COMMAND_CONFIG,
+		.help = "Set GPIO number for TRST.",
+		.usage = "[gpio]",
+	},
+	COMMAND_REGISTRATION_DONE
+};
+
+static const struct command_registration rp1_pio_jtag_command_handlers[] = {
+	{
+		.name = "rp1_pio_jtag",
+		.mode = COMMAND_ANY,
+		.help = "RP1 PIO JTAG adapter commands",
+		.chain = rp1_pio_jtag_subcommand_handlers,
+		.usage = "",
+	},
+	COMMAND_REGISTRATION_DONE
+};
+
+/* ---- Driver registration ---- */
+
+static struct jtag_interface rp1_pio_jtag_interface = {
+	.supported = DEBUG_CAP_TMS_SEQ,
+	.execute_queue = rp1_pio_jtag_execute_queue,
+};
+
+struct adapter_driver rp1_pio_jtag_adapter_driver = {
+	.name = "rp1_pio_jtag",
+	.transport_ids = TRANSPORT_JTAG,
+	.transport_preferred_id = TRANSPORT_JTAG,
+	.commands = rp1_pio_jtag_command_handlers,
+
+	.init = rp1_pio_jtag_init,
+	.quit = rp1_pio_jtag_quit,
+	.reset = rp1_pio_jtag_reset_handler,
+	.speed = rp1_pio_jtag_speed,
+	.khz = rp1_pio_jtag_khz,
+	.speed_div = rp1_pio_jtag_speed_div,
+
+	.jtag_ops = &rp1_pio_jtag_interface,
+};

--- a/drivers/openocd/rp1_pio_jtag.c
+++ b/drivers/openocd/rp1_pio_jtag.c
@@ -81,6 +81,22 @@ static int rp1_pio_state_move(enum tap_state goal)
 	uint8_t tdi_buf[2] = {0, 0};
 	enum tap_state cur = tap_get_state();
 
+	if (goal == TAP_RESET) {
+		/*
+		 * Always force a hardware TAP reset by clocking 5x TMS=1,
+		 * even if we think we're already in TLR.  This ensures the
+		 * physical TAP gets reset from any unknown state.
+		 */
+		tms_buf[0] = 0x1f; /* 5 bits of TMS=1 */
+		int ret = rp1_jtag_shift(rp1_dev, 5, tms_buf, tdi_buf, NULL);
+		if (ret < 0) {
+			LOG_ERROR("rp1_pio_jtag: TAP reset failed (%d)", ret);
+			return ERROR_FAIL;
+		}
+		tap_set_state(TAP_RESET);
+		return ERROR_OK;
+	}
+
 	if (cur == goal)
 		return ERROR_OK;
 
@@ -147,9 +163,26 @@ static int rp1_pio_handle_scan(struct scan_command *cmd)
 		return ERROR_FAIL;
 	}
 
-	/* After shifting with TMS=1 on last bit, TAP is in Exit1-xR */
-	enum tap_state exit_state = cmd->ir_scan ? TAP_IREXIT1 : TAP_DREXIT1;
-	tap_set_state(exit_state);
+	/* After shifting with TMS=1 on last bit, TAP is in Exit1-xR.
+	 * Exit1 is not a "stable" state, so we cannot use tap_get_tms_path()
+	 * directly.  Navigate to Run-Test/Idle via Update-xR first:
+	 *   Exit1-xR --(TMS=1)--> Update-xR --(TMS=0)--> Run-Test/Idle
+	 */
+	{
+		uint8_t post_tms[1] = {0x01}; /* bits: 1,0 = TMS high then low */
+		uint8_t post_tdi[1] = {0x00};
+		int post_ret = rp1_jtag_shift(rp1_dev, 2, post_tms, post_tdi,
+					      NULL);
+		if (post_ret < 0) {
+			LOG_ERROR("rp1_pio_jtag: post-scan nav failed (%d)",
+				  post_ret);
+			free(tdo);
+			free(tms);
+			free(tdi_buf);
+			return ERROR_FAIL;
+		}
+	}
+	tap_set_state(TAP_IDLE);
 
 	/* Copy TDO data back through OpenOCD's scan field machinery */
 	retval = jtag_read_buffer(tdo, cmd);

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -46,3 +46,10 @@ install(TARGETS rp1jtag rp1jtag_static
 install(FILES include/rp1_jtag.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
+
+# Generate and install pkg-config file
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/rp1jtag.pc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/rp1jtag.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/rp1jtag.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+)

--- a/lib/rp1jtag.pc.in
+++ b/lib/rp1jtag.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: rp1jtag
+Description: High-speed JTAG via Raspberry Pi 5 RP1 PIO
+Version: @PROJECT_VERSION@
+Libs: -L${libdir} -lrp1jtag
+Cflags: -I${includedir}

--- a/lib/src/rp1_jtag.c
+++ b/lib/src/rp1_jtag.c
@@ -314,9 +314,20 @@ static int pio_shift_fast_chunk(rp1_jtag_t *jtag,
     /* Enable SM — fast program starts immediately, stalls on autopull */
     be->ops->sm_set_enabled(be, true);
 
-    /* Try DMA path first */
-    bool use_dma = (be->ops->xfer_data != NULL &&
-                    ensure_dma_configured(jtag) == 0);
+    /*
+     * DMA path disabled: RP1 PIOLib's sequential TX-then-RX DMA causes
+     * data corruption (only bit 31 of each word after word 0 is valid).
+     * Root cause: the blocking TX DMA write completes before the SM
+     * finishes producing all RX words; the subsequent RX DMA read then
+     * races with the SM, likely getting autopush words out of alignment.
+     *
+     * The FIFO interleaving path (word-by-word sm_put/sm_get) is correct
+     * and still much faster than the counted program for large transfers
+     * since it avoids the 5-instr count-word overhead.
+     *
+     * TODO: investigate DMA with non-blocking / interrupt-driven approach.
+     */
+    bool use_dma = false;
 
     if (use_dma) {
         /*


### PR DESCRIPTION
OpenOCD driver implementation by GH Copilot. Tested working.

```
sudo /home/k8s/rp1-jtag/drivers/openocd/netv2_spiflash.sh flash /home/k8s/pcileech_netv2_top.bin
>>> Flashing /home/k8s/pcileech_netv2_top.bin (1629548 bytes) to SPI flash at offset 0...
>>>   bscan_spi: /home/k8s/netv2mvp-scripts/bscan_spi_xc7a35t.bit
Open On-Chip Debugger 0.12.0+dev-02420-g705257318-dirty (2026-02-28-10:25)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
netv2_spi_init
Info : rp1_pio_jtag: initializing RP1 PIO JTAG driver
Info : rp1_pio_jtag: TCK=4 TMS=17 TDI=27 TDO=22 SRST=-1 TRST=-1
Info : clock speed 1000 kHz
Info : JTAG tap: xc7.tap tap/device found: 0x0362d093 (mfg: 0x049 (Xilinx), part: 0x362d, ver: 0x0)
Info : [xc7.proxy] Examination succeed
Info : JTAG tap: xc7.tap tap/device found: 0x0362d093 (mfg: 0x049 (Xilinx), part: 0x362d, ver: 0x0)
Info : Found flash device 'mac 25l6405' (ID 0x1720c2)
flash 'jtagspi' found at 0x00000000
Info : sector 0 took 303 ms
Info : sector 1 took 307 ms
Info : sector 2 took 302 ms
Info : sector 3 took 285 ms
Info : sector 4 took 299 ms
Info : sector 5 took 292 ms
Info : sector 6 took 288 ms
Info : sector 7 took 289 ms
Info : sector 8 took 313 ms
Info : sector 9 took 308 ms
Info : sector 10 took 322 ms
Info : sector 11 took 306 ms
Info : sector 12 took 312 ms
Info : sector 13 took 292 ms
Info : sector 14 took 308 ms
Info : sector 15 took 279 ms
Info : sector 16 took 309 ms
Info : sector 17 took 302 ms
Info : sector 18 took 308 ms
Info : sector 19 took 304 ms
Info : sector 20 took 313 ms
Info : sector 21 took 297 ms
Info : sector 22 took 294 ms
Info : sector 23 took 298 ms
Info : sector 24 took 315 ms
read 1629548 bytes from file /home/k8s/pcileech_netv2_top.bin and flash bank 0 at offset 0x00000000 in 17.913561s (88.835 KiB/s)
contents match
shutdown command invoked
Info : rp1_pio_jtag: driver closed
>>> Flash complete. FPGA rebooted from SPI.
```