### PR TITLE
drivers/openfpgaloader: drop USE_DEVICE_ARG patches removed upstream

### DIFF
--- a/drivers/openfpgaloader/integrate.py
+++ b/drivers/openfpgaloader/integrate.py
@@ -165,21 +165,8 @@ def main() -> None:
         "CMake sources",
     )
 
-    # Add USE_DEVICE_ARG support (so --pins/--device CLI args work)
-    cmake = replace_once(
-        cmake,
-        'if (ENABLE_UDEV OR ENABLE_LIBGPIOD OR ENABLE_JETSONNANOGPIO)\n'
-        '\tadd_definitions(-DUSE_DEVICE_ARG)',
-        'if (ENABLE_UDEV OR ENABLE_LIBGPIOD OR ENABLE_JETSONNANOGPIO OR ENABLE_RP1_PIO)\n'
-        '\tadd_definitions(-DUSE_DEVICE_ARG)',
-        "CMake USE_DEVICE_ARG (if)",
-    )
-    cmake = replace_once(
-        cmake,
-        'endif(ENABLE_UDEV OR ENABLE_LIBGPIOD OR ENABLE_JETSONNANOGPIO)',
-        'endif(ENABLE_UDEV OR ENABLE_LIBGPIOD OR ENABLE_JETSONNANOGPIO OR ENABLE_RP1_PIO)',
-        "CMake USE_DEVICE_ARG (endif)",
-    )
+    # (No USE_DEVICE_ARG patch: upstream made --device/-d unconditional
+    # and removed the macro, so the previous ENABLE_RP1_PIO gate is moot.)
 
     # Add link libraries after the last LIBGPIOD endif block
     # The linking section is near the end of the file (after target_link_libraries)


### PR DESCRIPTION
## Summary

`integrate.py` currently fails on every push with:

```
Patching CMakeLists.txt...
  CMake option: applied
  CMake sources: applied
  ERROR: CMake USE_DEVICE_ARG (if): text not found
```

…which breaks both `deb-openfpgaloader.yml` (4 jobs) and `static-openfpgaloader.yml` against any recent upstream openFPGALoader checkout. Confirmed in the latest [#6 CI run](https://github.com/mithro/rp1-jtag/actions/runs/26554114893) (both arm64 and armhf fail identically, so this is upstream drift, not cross-arch).

## Root cause

Upstream openFPGALoader commit [`09838fa8`](https://github.com/trabucayre/openFPGALoader/commit/09838fa8) (2026-03-20, *"CMakeLists.txt, main: removed USE_DEVICE_ARG usage. Now --device/-d is always available"*) deleted:

- the `if (ENABLE_UDEV OR ENABLE_LIBGPIOD OR ENABLE_JETSONNANOGPIO) … add_definitions(-DUSE_DEVICE_ARG) endif(…)` block in `CMakeLists.txt`, and
- the matching `#if defined(USE_DEVICE_ARG)` guards around `("d,device", …)` in `src/main.cpp`.

Our two `replace_once` calls in `integrate.py` were extending that gate with `OR ENABLE_RP1_PIO`. With the gate gone there is nothing to extend, and `rp1PioJtag.{cpp,hpp}` never referenced the macro — `--device`/`-d` is now unconditionally available, which is what we wanted from the patch anyway.

## Change

Drop the two `replace_once` calls and their comment; leave a short note in their place so the deletion is obvious to future readers. No other `integrate.py` anchor drifted — verified by checking each anchor against upstream HEAD before editing.

## Verification

```
$ python3 integrate.py /tmp/openFPGALoader   # fresh 0818a404 clone
…
Patching CMakeLists.txt...
  CMake option: applied
  CMake sources: applied
  CMake link libraries: applied
$ cmake -B build -DENABLE_RP1_PIO=ON /tmp/openFPGALoader
-- Configuring done
-- Generating done
```

## Relationship to #6

Independent of #6 (the armhf matrix work) — that PR's `deb-rp1jtag.yml` jobs all pass, and its `deb-openfpgaloader.yml` jobs fail only on this upstream drift. Landing this first lets #6 ship green; otherwise #6's openFPGALoader jobs stay red after merge.

## Test plan

- [x] `integrate.py` runs cleanly against a fresh upstream clone (7/7 patches applied, 0 errors)
- [x] `cmake -B build -DENABLE_RP1_PIO=OFF` configures cleanly on the patched tree
- [x] `cmake -B build -DENABLE_RP1_PIO=ON` configures cleanly on the patched tree
- [ ] CI: `deb-openfpgaloader.yml` and `static-openfpgaloader.yml` go green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)