### PR TITLE
fix(ci): build only the PIOLib library target in the static build

### DIFF
--- a/.github/workflows/static-openfpgaloader.yml
+++ b/.github/workflows/static-openfpgaloader.yml
@@ -51,10 +51,11 @@ jobs:
               cd /work
 
               # Build and install PIOLib (provides /dev/pio0 hardware access).
-              # Only the library target and its install component: piolib's
+              # Only the library target and its install component: the piolib
               # examples (irqtest, irqtest2) link against gpiolib from the
               # sibling pinctrl/ tree, which is not built when piolib is
               # configured standalone, so a full build fails at link time.
+              # NOTE: no apostrophes in this script, it is single-quoted.
               git clone --depth 1 https://github.com/raspberrypi/utils.git /work/rpi-utils
               cmake -B /work/rpi-utils/piolib/build /work/rpi-utils/piolib \
                 -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/static-openfpgaloader.yml
+++ b/.github/workflows/static-openfpgaloader.yml
@@ -50,14 +50,18 @@ jobs:
               make install
               cd /work
 
-              # Build and install PIOLib (provides /dev/pio0 hardware access)
+              # Build and install PIOLib (provides /dev/pio0 hardware access).
+              # Only the library target and its install component: piolib's
+              # examples (irqtest, irqtest2) link against gpiolib from the
+              # sibling pinctrl/ tree, which is not built when piolib is
+              # configured standalone, so a full build fails at link time.
               git clone --depth 1 https://github.com/raspberrypi/utils.git /work/rpi-utils
               cmake -B /work/rpi-utils/piolib/build /work/rpi-utils/piolib \
                 -DCMAKE_BUILD_TYPE=Release \
                 -DCMAKE_INSTALL_PREFIX=/usr \
                 -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-              cmake --build /work/rpi-utils/piolib/build --parallel
-              cmake --install /work/rpi-utils/piolib/build
+              cmake --build /work/rpi-utils/piolib/build --parallel --target pio
+              cmake --install /work/rpi-utils/piolib/build --component piolib
 
               # Build and install librp1jtag (with PIOLib support)
               cmake -B /work/rp1-jtag/build /work/rp1-jtag \


### PR DESCRIPTION
## Summary

The `static arm64` job has been failing since upstream `raspberrypi/utils` added `irqtest`/`irqtest2` examples to `piolib` that link against `gpiolib` from the sibling `pinctrl/` tree. That library is never built when `piolib` is configured standalone, so the link fails:

```
ld: cannot find -lgpiolib: No such file or directory
gmake[2]: *** [examples/CMakeFiles/irqtest.dir/build.make:102: examples/irqtest] Error 1
```

This restricts the PIOLib step to `--target pio` and `--install --component piolib`, which is all the static openFPGALoader build consumes. Verified locally in an Alpine container that the target builds and the component install lands `libpio.a` plus the `piolib/` headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mXVtGsVsEN7Zh6C2TZQHp